### PR TITLE
feat(gpkg): Tile layers now use reprojection/stitching

### DIFF
--- a/externs/geopackage.js
+++ b/externs/geopackage.js
@@ -9,9 +9,14 @@
  *  id: !string,
  *  type: !string,
  *  data: (ArrayBuffer|Object|undefined),
+ *  extent: (ol.Extent|undefined),
+ *  projection: (string|undefined),
  *  tileCoord: (Array<number>|undefined),
  *  tableName: (string|undefined),
  *  url: (string|undefined),
+ *  height: (number|undefined),
+ *  width: (number|undefined),
+ *  zoom: (number|undefined),
  *  columns: ({field: string, type: string}|undefined)
  * }}
  */


### PR DESCRIPTION
Use the reprojection support in geopackage-js to allow the OpenSphere side to use a more typical XYZ grid with an extent and have geopackage-js stitch and resample the new tiles together. This allows better support from Cesium (especially for different origins per tile matrix), in addition to showing the raster layer in more resolutions than what may be defined in the GeoPackage (resulting in a better user experience).

Note: "reprojection" is an odd word here. By default, OpenSphere will still enforce the reprojection flag in config. In this case, GeoPackages in the application projection will simply be restitched/resampled into other tiles, but not reprojected. GeoPackages in another projection will ask the user to switch to that projection, just like all of our other layers.

Caveat:
The jpeg-js library that geopackage-js uses has some issues with some JPEG color support that the native browser JPEG library does not. For some GeoPackages I tested, I received the error:
```
Unsupported color mode (4 components)
```
I'm not sure if that is something that is incorrect from a JPEG-spec perspective and the browser native library is simply ignoring it, or if it is indicative of a lack of support for a feature in jpeg-js.