### PR TITLE
Add native library support

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "node-sass": "^4.7.2",
     "opensphere-build-closure-helper": "^1.0.0",
     "opensphere-build-docs": "^1.0.0",
-    "opensphere-build-resolver": "^2.1.0",
+    "opensphere-build-resolver": "^3.1.0",
     "replace": "^0.3.0",
     "rimraf": "^2.5.4",
     "sass-lint": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type": "plugin",
     "pluggable": false,
     "index": "index.js",
+    "electron": ["@ngageoint/geopackage"],
     "gcc": {
       "entry_point": [
         "goog:plugin.geopackage.GeoPackagePlugin"

--- a/src/worker/gpkg.worker.js
+++ b/src/worker/gpkg.worker.js
@@ -760,6 +760,18 @@ var window = this;
       process.send(msg);
     };
 
+    // CLEVER HACK ALERT!
+    // This script runs in either a Worker (web) or in a node child process (Electron).
+    // The child process has a node-only environment by default, rather than an Electron
+    // environment. However, electron-builder only packages the version built for the
+    // Electron environment.
+    //
+    // Therefore, trick node-pre-gyp into thinking we're in Electron.
+    // see associated env variable set in geopackage.js
+    if (process.env.ELECTRON_VERSION) {
+      process.versions.electron = process.env.ELECTRON_VERSION;
+    }
+
     geopackage = require('@ngageoint/geopackage');
   }
 })();


### PR DESCRIPTION
When this plugin is run through `opensphere-electron`, `geopackage-js` will use the `sqlite3` native bindings instead of the `sql.js` web package, allowing us to read large files directly off the disk.

Tested with GeoPackages of 700MB, 3.8GB, and 9GB in size.