### PR TITLE
feat(electron): use extra module path provided by electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,22 @@ Run `yarn` to install dependencies.
 
 ## Caveats
 
-Building the web version of OpenSphere still limits the file size to 100MB. The Electron version will soon support
+Building the web version of OpenSphere still limits the file size to 100MB. The Electron version supports
 large GeoPackage files.
 
 ## Tips
 
 After loading tiled imagery with a small coverage area, right-click the layer and select 'Go To'. That will get
 you close and you can zoom in a little further to see the imagery.
+
+
+# Electron
+
+## Building native deps on Windows
+
+ 1. Ensure python is installed (latest 2.7 should work; 3 might work but is untested on our end)
+ 2. Install [Microsoft Build Tools 2013](http://www.microsoft.com/en-us/download/details.aspx?id=40760)
+ 3. Restart
+ 4. `cd opensphere` and run `yarn build`
+ 4. `cd ../opensphere-electron` and run `yarn postinstall` and verify that there are no errors
+ 5. Run the app or create the installers per instructions in [opensphere-electron](https://github.com/ngageoint/opensphere-electron)

--- a/src/plugin/geopackage/geopackage.js
+++ b/src/plugin/geopackage/geopackage.js
@@ -93,12 +93,14 @@ plugin.geopackage.getWorker = function() {
       //
       // see associated hack in gpkg.worker.js
       var versions = window['process']['versions'];
-      var options = {};
+      var options = {
+        'env': {
+          'ELECTRON_EXTRA_PATH': window['process']['env']['ELECTRON_EXTRA_PATH']
+        }
+      };
 
-      if ('electron' in versions && !window['process']['env']['ELECTRON_IS_DEV']) {
-        options['env'] = {
-          'ELECTRON_VERSION': versions['electron']
-        };
+      if ('electron' in versions) {
+        options['env']['ELECTRON_VERSION'] = versions['electron'];
       }
 
       // to debug this guy:

--- a/src/worker/gpkg.worker.js
+++ b/src/worker/gpkg.worker.js
@@ -772,6 +772,10 @@ var window = this;
       process.versions.electron = process.env.ELECTRON_VERSION;
     }
 
+    if (process.env.ELECTRON_EXTRA_PATH) {
+      module.paths.unshift(process.env.ELECTRON_EXTRA_PATH);
+    }
+
     geopackage = require('@ngageoint/geopackage');
   }
 })();


### PR DESCRIPTION
When the native `sqlite3` dep is built by electron, it gets placed in `opensphere-electron/app/node_modules`, and opensphere-electron provides an environment variable with the location. Use that variable to prepend that path onto module.paths so that native deps are loaded from that location in dev, rather than relying on whatever was downloaded by yarn/npm to the project/hoisted node_modules.